### PR TITLE
Core Architecture & Setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require": {
         "php": "^8.3",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^11.0||^12.0"
+        "illuminate/contracts": "^11.0||^12.0",
+        "fattureincloud/fattureincloud-php-sdk": "^2.1"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
@@ -68,7 +69,7 @@
                 "Codeman\\LaravelFattureInCloudPhpSdk\\LaravelFattureInCloudPhpSdkServiceProvider"
             ],
             "aliases": {
-                "LaravelFattureInCloudPhpSdk": "Codeman\\LaravelFattureInCloudPhpSdk\\Facades\\LaravelFattureInCloudPhpSdk"
+                "FattureInCloud": "Codeman\\LaravelFattureInCloudPhpSdk\\Facades\\FattureInCloud"
             }
         }
     },

--- a/src/Commands/FattureInCloudCommand.php
+++ b/src/Commands/FattureInCloudCommand.php
@@ -4,11 +4,11 @@ namespace Codeman\LaravelFattureInCloudPhpSdk\Commands;
 
 use Illuminate\Console\Command;
 
-class LaravelFattureInCloudPhpSdkCommand extends Command
+class FattureInCloudCommand extends Command
 {
-    public $signature = 'laravel-fattureincloud-php-sdk';
+    public $signature = 'fatture-in-cloud';
 
-    public $description = 'My command';
+    public $description = 'FattureInCloud SDK command';
 
     public function handle(): int
     {

--- a/src/Facades/FattureInCloud.php
+++ b/src/Facades/FattureInCloud.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @see \Codeman\LaravelFattureInCloudPhpSdk\LaravelFattureInCloudPhpSdk
  */
-class LaravelFattureInCloudPhpSdk extends Facade
+class FattureInCloud extends Facade
 {
     protected static function getFacadeAccessor(): string
     {

--- a/src/LaravelFattureInCloudPhpSdkServiceProvider.php
+++ b/src/LaravelFattureInCloudPhpSdkServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Codeman\LaravelFattureInCloudPhpSdk;
 
+use Codeman\LaravelFattureInCloudPhpSdk\Commands\FattureInCloudCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Codeman\LaravelFattureInCloudPhpSdk\Commands\LaravelFattureInCloudPhpSdkCommand;
 
 class LaravelFattureInCloudPhpSdkServiceProvider extends PackageServiceProvider
 {
@@ -20,6 +20,6 @@ class LaravelFattureInCloudPhpSdkServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasViews()
             ->hasMigration('create_laravel_fattureincloud_php_sdk_table')
-            ->hasCommand(LaravelFattureInCloudPhpSdkCommand::class);
+            ->hasCommand(FattureInCloudCommand::class);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,9 @@
 
 namespace Codeman\LaravelFattureInCloudPhpSdk\Tests;
 
+use Codeman\LaravelFattureInCloudPhpSdk\LaravelFattureInCloudPhpSdkServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
-use Codeman\LaravelFattureInCloudPhpSdk\LaravelFattureInCloudPhpSdkServiceProvider;
 
 class TestCase extends Orchestra
 {


### PR DESCRIPTION
## Summary
- Add `fattureincloud/fattureincloud-php-sdk` dependency for Laravel wrapper
- Rename facade from `LaravelFattureInCloudPhpSdk` to `FattureInCloud` for cleaner API
- Update command name and signature for better developer experience

## Changes Made
### Dependencies
- ✅ Added `fattureincloud/fattureincloud-php-sdk: ^2.1` to composer.json
- ✅ Verified `spatie/laravel-package-tools` is already included

### Class Restructuring
- ✅ Renamed facade: `LaravelFattureInCloudPhpSdk` → `FattureInCloud`
- ✅ Renamed command: `LaravelFattureInCloudPhpSdkCommand` → `FattureInCloudCommand`  
- ✅ Updated command signature: `laravel-fattureincloud-php-sdk` → `fatture-in-cloud`
- ✅ Updated service provider imports and references
- ✅ Updated composer.json facade alias

## Test Results
- All tests passing (2/2)
- PHPStan static analysis clean (0 errors)
- Code formatted with Laravel Pint

## Breaking Changes
- Facade name changed from `LaravelFattureInCloudPhpSdk` to `FattureInCloud`
- Artisan command signature changed from `laravel-fattureincloud-php-sdk` to `fatture-in-cloud`

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)