### PR TITLE
Add OAuth2 helper methods for Laravel integration

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=visiaquantum_laravel-fattureincloud-php-sdk_3870c00b-027f-4c79-9b42-bbb4fce78f5f
-sonar.projectVersion=0.0.1
+sonar.projectVersion=0.0.2
 
 sonar.sources=src
 sonar.tests=tests

--- a/tests/OAuth2HelperMethodsTest.php
+++ b/tests/OAuth2HelperMethodsTest.php
@@ -1,0 +1,418 @@
+<?php
+
+use Codeman\FattureInCloud\Contracts\ApiServiceFactory;
+use Codeman\FattureInCloud\Contracts\OAuth2Manager;
+use Codeman\FattureInCloud\Contracts\TokenStorage;
+use Codeman\FattureInCloud\FattureInCloudSdk;
+use FattureInCloud\OAuth2\OAuth2TokenResponse;
+use FattureInCloud\OAuth2\Scope;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+describe('OAuth2 Helper Methods', function () {
+    beforeEach(function () {
+        // Mock dependencies
+        $this->oauthManager = Mockery::mock(OAuth2Manager::class);
+        $this->tokenStorage = Mockery::mock(TokenStorage::class);
+        $this->apiFactory = Mockery::mock(ApiServiceFactory::class);
+
+        // Create SDK instance with mocked dependencies
+        $this->sdk = new FattureInCloudSdk(
+            $this->oauthManager,
+            $this->tokenStorage,
+            $this->apiFactory,
+            'test-context'
+        );
+    });
+
+    afterEach(function () {
+        Mockery::close();
+    });
+
+    describe('redirectToAuthorization method', function () {
+        test('returns RedirectResponse when OAuth2 manager is initialized', function () {
+            // Arrange
+            $scopes = [Scope::ENTITY_CLIENTS_READ, Scope::ISSUED_DOCUMENTS_INVOICES_READ];
+            $authUrl = 'https://api-v2.fattureincloud.it/oauth/authorize?client_id=test&scopes='.urlencode(implode(' ', $scopes)).'&state=random-state';
+
+            $this->oauthManager
+                ->shouldReceive('isInitialized')
+                ->once()
+                ->andReturn(true);
+
+            $this->oauthManager
+                ->shouldReceive('getAuthorizationUrl')
+                ->once()
+                ->with($scopes, null)
+                ->andReturn($authUrl);
+
+            // Act
+            $response = $this->sdk->redirectToAuthorization($scopes);
+
+            // Assert
+            expect($response)->toBeInstanceOf(RedirectResponse::class);
+            expect($response->getTargetUrl())->toBe($authUrl);
+        });
+
+        test('throws LogicException when OAuth2 manager is not initialized', function () {
+            // Arrange
+            $scopes = [Scope::ENTITY_CLIENTS_READ];
+
+            $this->oauthManager
+                ->shouldReceive('isInitialized')
+                ->once()
+                ->andReturn(false);
+
+            // Act & Assert
+            expect(fn () => $this->sdk->redirectToAuthorization($scopes))
+                ->toThrow(
+                    \LogicException::class,
+                    'OAuth2 manager is not initialized. Please ensure FATTUREINCLOUD_CLIENT_ID and FATTUREINCLOUD_CLIENT_SECRET are configured.'
+                );
+        });
+
+        test('works with empty scopes array', function () {
+            // Arrange
+            $scopes = [];
+            $authUrl = 'https://api-v2.fattureincloud.it/oauth/authorize?client_id=test&scopes=&state=random-state';
+
+            $this->oauthManager
+                ->shouldReceive('isInitialized')
+                ->once()
+                ->andReturn(true);
+
+            $this->oauthManager
+                ->shouldReceive('getAuthorizationUrl')
+                ->once()
+                ->with($scopes, null)
+                ->andReturn($authUrl);
+
+            // Act
+            $response = $this->sdk->redirectToAuthorization($scopes);
+
+            // Assert
+            expect($response)->toBeInstanceOf(RedirectResponse::class);
+        });
+
+        test('works with multiple scopes', function () {
+            // Arrange
+            $scopes = [
+                Scope::ENTITY_CLIENTS_READ,
+                Scope::ISSUED_DOCUMENTS_INVOICES_ALL,
+                Scope::ENTITY_SUPPLIERS_READ,
+                Scope::PRODUCTS_READ,
+            ];
+            $authUrl = 'https://api-v2.fattureincloud.it/oauth/authorize?client_id=test&scopes='.urlencode(implode(' ', $scopes)).'&state=random-state';
+
+            $this->oauthManager
+                ->shouldReceive('isInitialized')
+                ->once()
+                ->andReturn(true);
+
+            $this->oauthManager
+                ->shouldReceive('getAuthorizationUrl')
+                ->once()
+                ->with($scopes, null)
+                ->andReturn($authUrl);
+
+            // Act
+            $response = $this->sdk->redirectToAuthorization($scopes);
+
+            // Assert
+            expect($response)->toBeInstanceOf(RedirectResponse::class);
+            expect($response->getTargetUrl())->toBe($authUrl);
+        });
+    });
+
+    describe('handleOAuth2Callback method', function () {
+        test('successfully handles valid callback with code and state', function () {
+            // Arrange
+            $code = 'auth-code-123';
+            $state = 'state-456';
+            $tokenResponse = Mockery::mock(OAuth2TokenResponse::class);
+
+            $request = new Request([
+                'code' => $code,
+                'state' => $state,
+            ]);
+
+            $this->oauthManager
+                ->shouldReceive('fetchToken')
+                ->once()
+                ->with($code, $state)
+                ->andReturn($tokenResponse);
+
+            $this->tokenStorage
+                ->shouldReceive('store')
+                ->once()
+                ->with('test-context', $tokenResponse);
+
+            // Act
+            $result = $this->sdk->handleOAuth2Callback($request);
+
+            // Assert
+            expect($result)->toBe($tokenResponse);
+        });
+
+        test('throws InvalidArgumentException when OAuth2 error is present', function () {
+            // Arrange
+            $request = new Request([
+                'error' => 'access_denied',
+                'error_description' => 'User denied authorization',
+            ]);
+
+            // Act & Assert
+            expect(fn () => $this->sdk->handleOAuth2Callback($request))
+                ->toThrow(
+                    \InvalidArgumentException::class,
+                    'OAuth2 authorization failed: access_denied - User denied authorization'
+                );
+        });
+
+        test('throws InvalidArgumentException when OAuth2 error is present without description', function () {
+            // Arrange
+            $request = new Request([
+                'error' => 'invalid_request',
+            ]);
+
+            // Act & Assert
+            expect(fn () => $this->sdk->handleOAuth2Callback($request))
+                ->toThrow(
+                    \InvalidArgumentException::class,
+                    'OAuth2 authorization failed: invalid_request'
+                );
+        });
+
+        test('throws InvalidArgumentException when code is missing', function () {
+            // Arrange
+            $request = new Request([
+                'state' => 'state-456',
+            ]);
+
+            // Act & Assert
+            expect(fn () => $this->sdk->handleOAuth2Callback($request))
+                ->toThrow(
+                    \InvalidArgumentException::class,
+                    'Missing required OAuth2 callback parameters: code and state are required'
+                );
+        });
+
+        test('throws InvalidArgumentException when state is missing', function () {
+            // Arrange
+            $request = new Request([
+                'code' => 'auth-code-123',
+            ]);
+
+            // Act & Assert
+            expect(fn () => $this->sdk->handleOAuth2Callback($request))
+                ->toThrow(
+                    \InvalidArgumentException::class,
+                    'Missing required OAuth2 callback parameters: code and state are required'
+                );
+        });
+
+        test('throws InvalidArgumentException when both code and state are missing', function () {
+            // Arrange
+            $request = new Request([]);
+
+            // Act & Assert
+            expect(fn () => $this->sdk->handleOAuth2Callback($request))
+                ->toThrow(
+                    \InvalidArgumentException::class,
+                    'Missing required OAuth2 callback parameters: code and state are required'
+                );
+        });
+
+        test('handles common OAuth2 error scenarios', function () {
+            $errorScenarios = [
+                ['access_denied', 'The user denied authorization'],
+                ['invalid_request', 'Invalid request parameters'],
+                ['invalid_client', 'Client authentication failed'],
+                ['invalid_grant', 'Authorization grant is invalid'],
+                ['unsupported_response_type', 'Response type not supported'],
+                ['invalid_scope', 'Requested scope is invalid'],
+                ['server_error', 'Server encountered an error'],
+                ['temporarily_unavailable', 'Service temporarily unavailable'],
+            ];
+
+            foreach ($errorScenarios as [$error, $description]) {
+                $request = new Request([
+                    'error' => $error,
+                    'error_description' => $description,
+                ]);
+
+                expect(fn () => $this->sdk->handleOAuth2Callback($request))
+                    ->toThrow(
+                        \InvalidArgumentException::class,
+                        "OAuth2 authorization failed: {$error} - {$description}"
+                    );
+            }
+        });
+
+        test('delegates to existing fetchToken method for token exchange', function () {
+            // Arrange
+            $code = 'auth-code-123';
+            $state = 'state-456';
+            $tokenResponse = Mockery::mock(OAuth2TokenResponse::class);
+
+            $request = new Request([
+                'code' => $code,
+                'state' => $state,
+            ]);
+
+            // Create a partial mock that allows us to verify fetchToken is called
+            $sdkMock = Mockery::mock(FattureInCloudSdk::class, [
+                $this->oauthManager,
+                $this->tokenStorage,
+                $this->apiFactory,
+                'test-context',
+            ])->makePartial();
+
+            $sdkMock
+                ->shouldReceive('fetchToken')
+                ->once()
+                ->with($code, $state)
+                ->andReturn($tokenResponse);
+
+            // Act
+            $result = $sdkMock->handleOAuth2Callback($request);
+
+            // Assert
+            expect($result)->toBe($tokenResponse);
+        });
+
+        test('handles empty string parameters as missing', function () {
+            // Arrange
+            $request = new Request([
+                'code' => '',
+                'state' => '',
+            ]);
+
+            // Act & Assert
+            expect(fn () => $this->sdk->handleOAuth2Callback($request))
+                ->toThrow(
+                    \InvalidArgumentException::class,
+                    'Missing required OAuth2 callback parameters: code and state are required'
+                );
+        });
+
+        test('handles null parameters as missing', function () {
+            // Arrange
+            $request = new Request([
+                'code' => null,
+                'state' => null,
+            ]);
+
+            // Act & Assert
+            expect(fn () => $this->sdk->handleOAuth2Callback($request))
+                ->toThrow(
+                    \InvalidArgumentException::class,
+                    'Missing required OAuth2 callback parameters: code and state are required'
+                );
+        });
+    });
+
+    describe('Integration with existing methods', function () {
+        test('redirectToAuthorization uses same OAuth2Manager as getAuthorizationUrl', function () {
+            // Arrange
+            $scopes = [Scope::ENTITY_CLIENTS_READ];
+            $authUrl = 'https://api-v2.fattureincloud.it/oauth/authorize?test';
+
+            $this->oauthManager
+                ->shouldReceive('isInitialized')
+                ->once()
+                ->andReturn(true);
+
+            $this->oauthManager
+                ->shouldReceive('getAuthorizationUrl')
+                ->twice() // Called once by redirectToAuthorization, once by getAuthorizationUrl
+                ->with($scopes, null) // getAuthorizationUrl has a default null state parameter
+                ->andReturn($authUrl);
+
+            // Act
+            $redirectResponse = $this->sdk->redirectToAuthorization($scopes);
+            $directUrl = $this->sdk->getAuthorizationUrl($scopes);
+
+            // Assert - both should use the same underlying OAuth2Manager
+            expect($redirectResponse->getTargetUrl())->toBe($authUrl);
+            expect($directUrl)->toBe($authUrl);
+        });
+
+        test('handleOAuth2Callback uses same fetchToken method', function () {
+            // Arrange
+            $code = 'auth-code-123';
+            $state = 'state-456';
+            $tokenResponse = Mockery::mock(OAuth2TokenResponse::class);
+
+            $request = new Request([
+                'code' => $code,
+                'state' => $state,
+            ]);
+
+            $this->oauthManager
+                ->shouldReceive('fetchToken')
+                ->twice() // Once for handleOAuth2Callback, once for direct fetchToken
+                ->with($code, $state)
+                ->andReturn($tokenResponse);
+
+            $this->tokenStorage
+                ->shouldReceive('store')
+                ->twice()
+                ->with('test-context', $tokenResponse);
+
+            // Act
+            $callbackResult = $this->sdk->handleOAuth2Callback($request);
+            $directResult = $this->sdk->fetchToken($code, $state);
+
+            // Assert - both should return the same token response
+            expect($callbackResult)->toBe($tokenResponse);
+            expect($directResult)->toBe($tokenResponse);
+        });
+    });
+
+    describe('Error propagation', function () {
+        test('redirectToAuthorization propagates OAuth2Manager exceptions', function () {
+            // Arrange
+            $scopes = [Scope::ENTITY_CLIENTS_READ];
+
+            $this->oauthManager
+                ->shouldReceive('isInitialized')
+                ->once()
+                ->andReturn(true);
+
+            $this->oauthManager
+                ->shouldReceive('getAuthorizationUrl')
+                ->once()
+                ->with($scopes, null)
+                ->andThrow(new \InvalidArgumentException('Invalid scope'));
+
+            // Act & Assert
+            expect(fn () => $this->sdk->redirectToAuthorization($scopes))
+                ->toThrow(\InvalidArgumentException::class, 'Invalid scope');
+        });
+
+        test('handleOAuth2Callback propagates fetchToken exceptions', function () {
+            // Arrange
+            $code = 'invalid-code';
+            $state = 'invalid-state';
+
+            $request = new Request([
+                'code' => $code,
+                'state' => $state,
+            ]);
+
+            $this->oauthManager
+                ->shouldReceive('fetchToken')
+                ->once()
+                ->with($code, $state)
+                ->andThrow(new \InvalidArgumentException('Invalid state parameter'));
+
+            // Don't expect tokenStorage to be called since fetchToken throws
+            $this->tokenStorage->shouldNotReceive('store');
+
+            // Act & Assert
+            expect(fn () => $this->sdk->handleOAuth2Callback($request))
+                ->toThrow(\InvalidArgumentException::class, 'Invalid state parameter');
+        });
+    });
+});


### PR DESCRIPTION
## 🚀 OAuth2 Helper Methods Implementation

Implements high-level OAuth2 flow helper methods to simplify Laravel integration, addressing issue #15.

### ✅ **New Methods**

#### `redirectToAuthorization(array $scopes): RedirectResponse`
- Generates OAuth2 authorization URL and returns Laravel `RedirectResponse`
- Validates OAuth2 manager initialization
- Supports all Fatture in Cloud OAuth2 scopes
- Throws `LogicException` with helpful error messages

#### `handleOAuth2Callback(Request $request): OAuth2TokenResponse`
- Processes OAuth2 callback parameters from Laravel `Request`
- Comprehensive error handling for OAuth2 errors (`access_denied`, `invalid_request`, etc.)
- Validates required parameters (`code`, `state`)
- Exchanges authorization code for access/refresh tokens
- Automatically stores tokens using existing infrastructure

### 🎯 **Key Features**

- **Laravel-Native Integration**: Uses `Request`/`RedirectResponse` objects
- **Comprehensive Error Handling**: Descriptive exception messages for all failure scenarios
- **Architectural Consistency**: Follows existing codebase patterns and conventions
- **Security**: Proper OAuth2 error validation and state parameter handling
- **Auto Token Management**: Seamless integration with existing token storage system

### 🧪 **Quality Assurance**

- ✅ **18 comprehensive unit tests** with 65 assertions
- ✅ **Full error coverage** including edge cases and integration scenarios
- ✅ **All existing tests pass** (67 tests, 221 assertions total)
- ✅ **PHPStan clean** (0 errors reported)
- ✅ **SonarQube compliant** (Quality Gate: PASSED, 0 issues)
- ✅ **Laravel Pint formatted** (coding standards applied)

### 📚 **Usage Examples**

```php
// Starting OAuth2 flow
public function auth(FattureInCloudSdk $sdk)
{
    return $sdk->redirectToAuthorization([
        Scope::ENTITY_CLIENTS_READ,
        Scope::ISSUED_DOCUMENTS_INVOICES_ALL
    ]);
}

// Handling OAuth2 callback
public function callback(Request $request, FattureInCloudSdk $sdk)
{
    try {
        $tokenResponse = $sdk->handleOAuth2Callback($request);
        return redirect('/dashboard')->with('success', 'Authentication successful!');
    } catch (\InvalidArgumentException $e) {
        return redirect('/auth')->with('error', 'Authentication failed: ' . $e->getMessage());
    }
}
```

### ❌ **Intentionally NOT Implemented**

Based on architectural analysis, the following methods were **NOT** implemented:
- `isAuthenticated(): bool` - Violates single responsibility, duplicates existing token management
- `getCurrentUser(): ?User` - Application-level concern, conflicts with Laravel Auth patterns

**Rationale**: The existing token management system (`isTokenExpired()`, `ensureValidToken()`, API service access) already provides proper authentication state handling without introducing architectural violations.

### 📈 **Benefits**

- **Reduced Boilerplate**: Eliminates manual URL generation and parameter handling
- **Better DX**: Laravel-native objects and error handling
- **Maintainable**: Clean separation of concerns, well-documented code
- **Secure**: Proper OAuth2 flow implementation with comprehensive error handling
- **Testable**: Full unit test coverage with proper mocking

### 🔗 **Related**

- Closes #15
- Maintains compatibility with existing OAuth2 implementation
- No breaking changes to public API

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>